### PR TITLE
V1.0.0

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,90 @@
+{
+    // JSHint Default Configuration File (as on JSHint website)
+    // See http://jshint.com/docs/ for more details
+
+    "maxerr"        : 50,       // {int} Maximum error before stopping
+
+    // Enforcing
+    "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
+    "camelcase"     : false,    // true: Identifiers must be in camelCase
+    "curly"         : false,    // true: Require {} for every new block or scope
+    "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+    "forin"         : false,    // true: Require filtering for..in loops with obj.hasOwnProperty()
+    "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
+    "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+    "indent"        : 4,        // {int} Number of spaces to use for indentation
+    "latedef"       : false,    // true: Require variables/functions to be defined before being used
+    "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
+    "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
+    "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
+    "plusplus"      : false,    // true: Prohibit use of `++` & `--`
+    "quotmark"      : false,    // Quotation mark consistency:
+                                //   false    : do nothing (default)
+                                //   true     : ensure whatever is used is consistent
+                                //   "single" : require single quotes
+                                //   "double" : require double quotes
+    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "unused"        : true,     // true: Require all defined variables be used
+    "strict"        : false,     // true: Requires all functions run in ES5 Strict Mode
+    "maxparams"     : false,    // {int} Max number of formal params allowed per function
+    "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
+    "maxstatements" : false,    // {int} Max number statements per function
+    "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
+    "maxlen"        : false,    // {int} Max number of characters per line
+
+    // Relaxing
+    "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)
+    "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
+    "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
+    "eqnull"        : false,     // true: Tolerate use of `== null`
+    "es5"           : false,     // true: Allow ES5 syntax (ex: getters and setters)
+    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
+                                 // (ex: `for each`, multiple try/catch, function expression…)
+    "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
+    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+    "funcscope"     : false,     // true: Tolerate defining variables inside control statements
+    "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
+    "iterator"      : false,     // true: Tolerate using the `__iterator__` property
+    "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
+    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+    "laxcomma"      : false,     // true: Tolerate comma-first style coding
+    "loopfunc"      : false,     // true: Tolerate functions being defined in loops
+    "multistr"      : false,     // true: Tolerate multi-line strings
+    "noyield"       : false,     // true: Tolerate generator functions with no yield statement in them.
+    "notypeof"      : false,     // true: Tolerate invalid typeof operator values
+    "proto"         : false,     // true: Tolerate using the `__proto__` property
+    "scripturl"     : false,     // true: Tolerate script-targeted URLs
+    "shadow"        : false,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
+    "sub"           : false,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+    "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
+    "validthis"     : false,     // true: Tolerate using this in a non-constructor function
+
+    // Environments
+    "browser"       : false,    // Web Browser (window, document, etc)
+    "browserify"    : false,    // Browserify (node.js code in the browser)
+    "couch"         : false,    // CouchDB
+    "devel"         : true,     // Development/debugging (alert, confirm, etc)
+    "dojo"          : false,    // Dojo Toolkit
+    "jasmine"       : false,    // Jasmine
+    "jquery"        : false,    // jQuery
+    "mocha"         : true,     // Mocha
+    "mootools"      : false,    // MooTools
+    "node"          : true,     // Node.js
+    "nonstandard"   : false,    // Widely adopted globals (escape, unescape, etc)
+    "prototypejs"   : false,    // Prototype and Scriptaculous
+    "qunit"         : false,    // QUnit
+    "rhino"         : false,    // Rhino
+    "shelljs"       : false,    // ShellJS
+    "worker"        : false,    // Web Workers
+    "wsh"           : false,    // Windows Scripting Host
+    "yui"           : false,    // Yahoo User Interface
+
+    // Custom Globals
+    "globals"       : {
+      // server globals
+      
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+    - "0.12.4"
+before_install:
+    - "npm install -g npm"
+    - "npm install -g grunt-cli"
+install:
+    - "npm install"
+before_script:
+    - grunt yellowlabtools:twitterLocal
+    - grunt yellowlabtools:twitterDistant

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
                     'https://twitter.com/tos'
                 ],
                 failConditions: [
-                    'fail if at least one url has a global score < 70/100'
+                    'fail if at least one url has a global score < 20/100'
                 ],
                 options: {
                     locally: true
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
                     'https://twitter.com/tos'
                 ],
                 failConditions: [
-                    'fail if at least one url has a global score < 70/100'
+                    'fail if at least one url has a global score < 20/100'
                 ],
                 options: {
                     locally: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,14 +34,29 @@ module.exports = function(grunt) {
 
         // Configuration to be run (and then tested).
         yellowlabtools: {
-            twitter: {
+            twitterLocal: {
                 urls: [
                     'https://twitter.com',
                     'https://twitter.com/tos'
                 ],
                 failConditions: [
                     'fail if at least one url has a global score < 70/100'
-                ]
+                ],
+                options: {
+                    locally: true
+                }
+            },
+            twitterDistant: {
+                urls: [
+                    'https://twitter.com',
+                    'https://twitter.com/tos'
+                ],
+                failConditions: [
+                    'fail if at least one url has a global score < 70/100'
+                ],
+                options: {
+                    locally: false
+                }
             },
             github: {
                 urls: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
                     'https://twitter.com/tos'
                 ],
                 failConditions: [
-                    'fail if at least one url has a global score < 20/100'
+                    'fail if at least one url has a global score < 1/100'
                 ],
                 options: {
                     locally: true
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
                     'https://twitter.com/tos'
                 ],
                 failConditions: [
-                    'fail if at least one url has a global score < 20/100'
+                    'fail if at least one url has a global score < 1/100'
                 ],
                 options: {
                     locally: false

--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ grunt.initConfig({
 
         // For each rule, you can check directly the metric instead of the score by omitting '/100'
         'fail if at least one url has a domElementsCount > 2000'
-      ]
+      ],
+      options: {
+
+      }
     }
   }
 });
@@ -77,8 +80,27 @@ grunt.initConfig({
 
 ### Options
 
-Coming soon
+##### device [String]
+Use "phone" or "tablet" to simulate a mobile device (by user-agent and viewport size). Default is "desktop".
 
+##### cookie [String]
+Adds a cookie on the main domain. Example: `bar=foo;domain=url`.
+
+##### authUser [String] & authPass [String]
+Your credentials if you need to bypass a basic HTTP authentication. 
+If your authentication is not basic, you might be able to copy the session cookie from your browser, paste it in the "Cookie" setting and launch a run before your cookie expires.
+
+##### locally [Boolean]
+By default, runs are launched locally, using the NodeJS version of YLT (without the HTML user interface). If you want to run the tests remotely on a YLT server (the public instance or your own instance, set this boolean to false). Default is true. 
+Please note that local tests are much faster than the YLT's public instance, where your runs will be queued and limited to 50 runs per day.
+
+##### serverUrl [String]
+When `locally` is false, this is the url of the server you want to run the tests on. Default is the public instance `http://yellowlab.tools`. 
+If you need to launch more runs (or for any other reason), you can run the test on your own private instance (see [How to install your private server](https://github.com/gmetais/YellowLabTools/wiki/Install-your-private-server)).
+
+##### apiKey [String]
+To avoid abuse and keep the service free for everyone, the API will block your IP if you launched more than 50 runs in the last 24h. 
+If you have a good reason, please email me so I can give you an api-key. You can also create and host [your private instance](https://github.com/gmetais/YellowLabTools/wiki/Install-your-private-server).
 
 
 ### Usage Examples

--- a/README.md
+++ b/README.md
@@ -191,6 +191,20 @@ Defining a threshold on a metric overrides any score threshold you might have de
 
 Here is the list of rules you can threshold.
 
+#### Page weight
+* totalWeight: total number of bytes downloaded
+* imageOptimization: number of bytes that could be saved by optimising images
+* gzipCompression: number of bytes that could be saved by compressing file transfers
+* fileMinification: number of bytes that could be saved by minifying JS, CSS and HTML
+
+#### Requests
+* totalRequests: total number of HTTP requests made
+* domains: number of domains used
+* notFound: number of HTTP 404 responses
+* multipleRequests: number of static assets that are requested more than once
+* smallRequests: requests that are smaller than 2 KB
+* lazyLoadableImagesBelowTheFold: images displayed below the fold that could be lazy-loaded
+
 #### DOM complexity
 * DOMelementsCount: total number of HTML element nodes
 * DOMelementMaxDepth: maximum level on nesting of HTML element node
@@ -212,7 +226,7 @@ Here is the list of rules you can threshold.
 * consoleMessages: number of calls to console.* functions
 * globalVariables: number of JS globals variables
 
-#### jQuery version
+#### jQuery
 * jQueryVersion: version of jQuery framework (if loaded)
 * jQueryVersionsLoaded: number of loaded jQuery "instances"
 * jQueryFunctionsUsed: number of different core jQuery functions called on load
@@ -239,31 +253,11 @@ Here is the list of rules you can threshold.
 * cssRedundantBodySelectors: number of redundant body selectors (e.g. `body .foo`)
 * cssRedundantChildNodesSelectors: number of redundant child nodes selectors (e.g. `ul li`, `table tr`)
 
-#### Requests number
-* requests: total number of HTTP requests made
-* htmlCount: number of HTML responses
-* jsCount: number of JS responses
-* cssCount: number of CSS responses
-* imageCount: number of image responses
-* webfontCount: number of web font responses
-* videoCount: number of video responses
-* jsonCount: number of JSON responses
-* otherCount: number of other responses
-
-#### Small requests
-* smallJsFiles: number of JS assets smaller than 2 KB
-* smallCssFiles: number of CSS assets smaller than 2 KB
-* smallImages: images smaller than 2 KB
-
-#### Network
-* notFound: number of HTTP 404 responses
-* assetsNotGzipped: number of requests that should be compressed with gzip but aren't
+#### Server config
 * closedConnections: number of requests not keeping the connection alive
-* multipleRequests: number of static assets that are requested more than once
-* cachingDisabled: responses with caching disabled
 * cachingNotSpecified: responses with no caching header sent
+* cachingDisabled: responses with caching disabled
 * cachingTooShort: responses with too short caching time (less than a week)
-* domains: number of domains used
 
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I recommend using this grunt task if:
  - you're a team and you're practicing continous integration
 
 
-Unlike most of the similar tools ([grunt-pagespeed](https://github.com/jrcryer/grunt-pagespeed), [grunt-perfbudget](https://github.com/tkadlec/grunt-perfbudget), [grunt-pagespeedio](https://github.com/sitespeedio/grunt-sitespeedio)), grunt-yellowlabtools runs **locally** instead of calling a server you don't own. This is great for testing non-public pages!
+Unlike most of the similar tools ([grunt-pagespeed](https://github.com/jrcryer/grunt-pagespeed), [grunt-perfbudget](https://github.com/tkadlec/grunt-perfbudget), [grunt-pagespeedio](https://github.com/sitespeedio/grunt-sitespeedio)), grunt-yellowlabtools can run **locally** (default behavior), instead of calling a server you don't own. This is great for testing non-public pages!
 
 
 
@@ -70,7 +70,7 @@ grunt.initConfig({
         'fail if at least one url has a domElementsCount > 2000'
       ],
       options: {
-
+        device: 'mobile'
       }
     }
   }
@@ -87,19 +87,20 @@ Use "phone" or "tablet" to simulate a mobile device (by user-agent and viewport 
 Adds a cookie on the main domain. Example: `bar=foo;domain=url`.
 
 ##### authUser [String] & authPass [String]
-Your credentials if you need to bypass a basic HTTP authentication. 
+Your credentials if you need to bypass a basic HTTP authentication.  
 If your authentication is not basic, you might be able to copy the session cookie from your browser, paste it in the "Cookie" setting and launch a run before your cookie expires.
 
 ##### locally [Boolean]
-By default, runs are launched locally, using the NodeJS version of YLT (without the HTML user interface). If you want to run the tests remotely on a YLT server (the public instance or your own instance, set this boolean to false). Default is true. 
-Please note that local tests are much faster than the YLT's public instance, where your runs will be queued and limited to 50 runs per day.
+By default, runs are launched locally, using the NodeJS version of YLT (without the HTML user interface). If you want to run the tests remotely on a YLT server (the public instance or your own instance), set this boolean to false. Default is true.  
+Please note that local tests are much faster than the YLT's public instance, where your runs will be queued and limited to 50 runs per day.  
+However, running on a distant server provides you with the url of the HTML report, and that's pretty cool!
 
 ##### serverUrl [String]
-When `locally` is false, this is the url of the server you want to run the tests on. Default is the public instance `http://yellowlab.tools`. 
+When `locally` is false, this is the url of the server you want to run the tests on. Default is the public instance `http://yellowlab.tools`.  
 If you need to launch more runs (or for any other reason), you can run the test on your own private instance (see [How to install your private server](https://github.com/gmetais/YellowLabTools/wiki/Install-your-private-server)).
 
 ##### apiKey [String]
-To avoid abuse and keep the service free for everyone, the API will block your IP if you launched more than 50 runs in the last 24h. 
+To avoid abuse and keep the service free for everyone, the API will block your IP if you launched more than 50 runs in the last 24h.  
 If you have a good reason, please email me so I can give you an api-key. You can also create and host [your private instance](https://github.com/gmetais/YellowLabTools/wiki/Install-your-private-server).
 
 

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "async": "^1.0.0",
-    "q": "^1.4.1",
-    "yellowlabtools": "^1.7.2"
+    "async": "1.4.0",
+    "q": "1.4.1",
+    "yellowlabtools": "1.7.2"
   },
   "devDependencies": {
-    "chai": "^2.3.0",
+    "chai": "^3.2.0",
     "grunt": "~0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.11.2",
@@ -42,8 +42,8 @@
     "matchdep": "^0.3.0",
     "mocha": "^2.2.5",
     "request": "2.59.0",
-    "sinon": "^1.14.1",
-    "sinon-chai": "^2.7.0"
+    "sinon": "^1.15.4",
+    "sinon-chai": "^2.8.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.5"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "async": "^1.0.0",
     "q": "^1.4.1",
-    "yellowlabtools": "^1.6.0"
+    "yellowlabtools": "^1.7.2"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-yellowlabtools",
   "description": "Grunt plugin for YellowLabTools",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "homepage": "https://github.com/gmetais/grunt-yellowlabtools",
   "author": {
     "name": "Gaël Métais",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "grunt-mocha-test": "^0.12.7",
     "matchdep": "^0.3.0",
     "mocha": "^2.2.5",
+    "request": "2.59.0",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0"
   },

--- a/tasks/lib/distantRunner.js
+++ b/tasks/lib/distantRunner.js
@@ -1,0 +1,90 @@
+var async   = require('async');
+var Q       = require('q');
+var request = require('request');
+
+var DistantRunner = function(grunt) {
+    
+    this.launchRuns = function(urls, options) {
+        var deferred = Q.defer();
+
+        var results = [];
+        var currentUrl;
+
+        async.whilst(function() {
+            return urls.length > 0;
+        }, function(callback) {
+            
+            currentUrl = urls.shift();
+
+            var startTime = Date.now();
+            grunt.log.writeln('Sending the run to the server ', currentUrl);
+            
+            
+
+            requestRunAndWaitForResponse(currentUrl, options)
+
+                .then(function(runResult) {
+                    var endTime = Date.now();
+                    grunt.log.writeln(' [Global score is %d/100] (took %dms) ', runResult.scoreProfiles.generic.globalScore, endTime - startTime);
+                    results.push(runResult);
+                    callback();
+                })
+
+                .fail(callback);
+
+        }, function(error) {
+            if (error) {
+                grunt.log.error('YellowLabTools run failed on page %s with error: %d', currentUrl, error);
+                deferred.reject(error);
+            } else {
+                deferred.resolve(results);
+            }
+        });
+
+        return deferred.promise;
+    };
+
+    function requestRunAndWaitForResponse(url, options) {
+        var deferred = Q.defer();
+
+        var yltOptions = {
+            url: url,
+            waitForResponse: true,
+            screenshot: true,
+            jsTimeline: true,
+            device: options.device,
+            //waitForSelector: options.waitForSelector,
+            cookie: options.cookie,
+            authUser: options.authUser,
+            authPass: options.authPass
+        };
+
+        var reqOptions = {
+            method: 'POST',
+            json: true,
+            followAllRedirects: true,
+            uri: 'http://yellowlab.tools/api/runs',
+            body: yltOptions
+        };
+
+        // API Key option
+        if (options.apiKey) {
+            reqOptions.headers = {
+                'x-api-key': options.apiKey
+            };
+        }
+
+        request(reqOptions, function(error, response, body) {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                deferred.resolve(body);
+            }
+        });
+
+        return deferred.promise;
+    }
+
+};
+
+module.exports = DistantRunner;

--- a/tasks/lib/distantRunner.js
+++ b/tasks/lib/distantRunner.js
@@ -25,7 +25,8 @@ var DistantRunner = function(grunt) {
 
                 .then(function(runResult) {
                     var endTime = Date.now();
-                    grunt.log.writeln(' [Global score is %d/100] (took %dms) ', runResult.scoreProfiles.generic.globalScore, endTime - startTime);
+                    var resultsUrl = options.serverUrl + '/result/' + runResult.runId;
+                    grunt.log.writeln(' [Global score is %d/100] (took %dms) - Details here: %s', runResult.scoreProfiles.generic.globalScore, endTime - startTime, resultsUrl);
                     results.push(runResult);
                     callback();
                 })

--- a/tasks/lib/distantRunner.js
+++ b/tasks/lib/distantRunner.js
@@ -23,20 +23,20 @@ var DistantRunner = function(grunt) {
 
             requestRunAndWaitForResponse(currentUrl, options)
 
-                .then(function(runResult) {
-                    var endTime = Date.now();
-                    var resultsUrl = options.serverUrl + '/result/' + runResult.runId;
-                    grunt.log.writeln(' [Global score is %d/100] (took %dms) - Details here: %s', runResult.scoreProfiles.generic.globalScore, endTime - startTime, resultsUrl);
-                    results.push(runResult);
-                    callback();
-                })
+            .then(function(runResult) {
+                var endTime = Date.now();
 
-                .fail(callback);
+                var resultsUrl = options.serverUrl + '/result/' + runResult.runId;
+                grunt.log.writeln(' [Global score is %d/100] (took %dms) - Details here: %s', runResult.scoreProfiles.generic.globalScore, endTime - startTime, resultsUrl);
+                results.push(runResult);
+                callback();
+            })
+
+            .fail(callback);
 
         }, function(error) {
             if (error) {
-                grunt.log.error('YellowLabTools run failed on page %s with error: %d', currentUrl, error);
-                deferred.reject(error);
+                deferred.reject('YellowLabTools run failed on page ' + currentUrl + ' with error: ' + error);
             } else {
                 deferred.resolve(results);
             }
@@ -78,7 +78,9 @@ var DistantRunner = function(grunt) {
         request(reqOptions, function(error, response, body) {
             if (error) {
                 deferred.reject(error);
-            } else {
+            } else if (response.statusCode !== 200) {
+                deferred.reject(response.statusCode + ' ' + response.body);
+            }else {
                 deferred.resolve(body);
             }
         });

--- a/tasks/lib/localRunner.js
+++ b/tasks/lib/localRunner.js
@@ -29,19 +29,18 @@ var LocalRunner = function(grunt) {
             
             ylt(currentUrl, yltOptions)
 
-                .then(function(runResult) {
-                    var endTime = Date.now();
-                    grunt.log.writeln(' [Global score is %d/100] (took %dms) ', runResult.scoreProfiles.generic.globalScore, endTime - startTime);
-                    results.push(runResult);
-                    callback();
-                })
+            .then(function(runResult) {
+                var endTime = Date.now();
+                grunt.log.writeln(' [Global score is %d/100] (took %dms) ', runResult.scoreProfiles.generic.globalScore, endTime - startTime);
+                results.push(runResult);
+                callback();
+            })
 
-                .fail(callback);
+            .fail(callback);
 
         }, function(error) {
             if (error) {
-                grunt.log.error('YellowLabTools run failed on page %s with error: %d', currentUrl, error);
-                deferred.reject(error);
+                deferred.reject('YellowLabTools run failed on page ' + currentUrl + ' with error: ' + error);
             } else {
                 deferred.resolve(results);
             }

--- a/tasks/lib/localRunner.js
+++ b/tasks/lib/localRunner.js
@@ -4,7 +4,7 @@ var ylt     = require('yellowlabtools');
 
 var LocalRunner = function(grunt) {
     
-    this.launchRuns = function(urls) {
+    this.launchRuns = function(urls, options) {
         var deferred = Q.defer();
 
         var results = [];
@@ -16,10 +16,18 @@ var LocalRunner = function(grunt) {
             
             currentUrl = urls.shift();
 
+            var yltOptions = {
+                device: options.device,
+                //waitForSelector: options.waitForSelector,
+                cookie: options.cookie,
+                authUser: options.authUser,
+                authPass: options.authPass
+            };
+
             var startTime = Date.now();
             grunt.log.writeln('Loading the page %s in PhantomJS... ', currentUrl);
             
-            ylt(currentUrl)
+            ylt(currentUrl, yltOptions)
 
                 .then(function(runResult) {
                     var endTime = Date.now();

--- a/tasks/yellowlabtools.js
+++ b/tasks/yellowlabtools.js
@@ -8,8 +8,9 @@
 
 'use strict';
 
-var LocalRunner = require('./lib/localRunner');
-var conditions = require('./lib/conditions');
+var LocalRunner     = require('./lib/localRunner');
+var DistantRunner   = require('./lib/distantRunner');
+var conditions      = require('./lib/conditions');
 
 
 module.exports = function(grunt) {
@@ -27,16 +28,25 @@ module.exports = function(grunt) {
         }
 
         var done = this.async();
-        var localRunner = new LocalRunner(grunt);
+
         var options = this.options({
-      
+            locally: true,
+            serverUrl: 'http://yellowlab.tools',
+            device: 'desktop'
         });
+
+        var runner;
+        if (options.locally) {
+            runner = new LocalRunner(grunt);
+        } else {
+            runner = new DistantRunner(grunt);
+        }
 
         conditions.parsePhraseConditions(failConditions)
 
             .then(function(obj) {
                 conditionsObject = obj;
-                return localRunner.launchRuns(urls);
+                return runner.launchRuns(urls, options);
             })
 
             .then(function(results) {

--- a/test/localRunnerTest.js
+++ b/test/localRunnerTest.js
@@ -37,7 +37,7 @@ describe('localRunner', function() {
 
         var url = 'http://localhost:8388/simple-page.html';
 
-        localRunner.launchRuns([url])
+        localRunner.launchRuns([url], {})
             .then(function(results) {
 
                 results.should.be.an('array');
@@ -71,7 +71,7 @@ describe('localRunner', function() {
 
         var url = 'http://localhost:8388/simple-page.html';
 
-        localRunner.launchRuns([url, url])
+        localRunner.launchRuns([url, url], {})
             .then(function(results) {
 
                 results.should.be.an('array');


### PR DESCRIPTION
### Distant runs

In version v0.0, you were only able to run a test locally. This release adds the possibility to run the test distantly (on the public instance or on your own instance), with the `locally` option.
### Other options

You can now add running options in the Gruntfile: **device**, **cookie**, **basic HTTP auth**.
### Updates

**Yellow Lab Tools** updated to **v1.7** ([read the release note](https://github.com/gmetais/YellowLabTools/releases/tag/v1.7.0))
