### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "async": "1.4.0",
+    "async": "1.4.2",
     "q": "1.4.1",
-    "request": "2.59.0",
-    "yellowlabtools": "1.7.2"
+    "request": "2.62.0",
+    "yellowlabtools": "1.7.8"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-yellowlabtools",
   "description": "Grunt plugin for YellowLabTools",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "homepage": "https://github.com/gmetais/grunt-yellowlabtools",
   "author": {
     "name": "Gaël Métais",


### PR DESCRIPTION
Updating YellowLabTools to 1.7.8. Tests can now be launched with basic HTTP authentication.
